### PR TITLE
feat(LIB): Update LIB and iob_regfileif_setup.py accordingly

### DIFF
--- a/iob_regfileif_setup.py
+++ b/iob_regfileif_setup.py
@@ -10,8 +10,9 @@ import copy
 name='iob_regfileif'
 version='V0.10'
 flows='sim'
-setup_dir=os.path.dirname(__file__)
-build_dir=f"../{name}_{version}"
+if setup.is_top_module(sys.modules[__name__]):
+    setup_dir=os.path.dirname(__file__)
+    build_dir=f"../{name}_{version}"
 submodules = {
     'hw_setup': {
         'headers' : [ 'iob_s_port', 'iob_s_portmap' ],

--- a/nativebridgeif_wrappper/iob_nativebridgeif_setup.py
+++ b/nativebridgeif_wrappper/iob_nativebridgeif_setup.py
@@ -14,7 +14,8 @@ regfileif_core_module=import_setup(f"{setup_dir}/..")
 # Copy some fields from the regfileif core
 version=regfileif_core_module.version
 flows=regfileif_core_module.flows
-build_dir=f"../{name}_{version}"
+if setup.is_top_module(sys.modules[__name__]):
+    build_dir=f"../{name}_{version}"
 
 confs = regfileif_core_module.confs
 


### PR DESCRIPTION
The setup and build directories should only be set if the module is not being imported by another (if the module is not the top module).